### PR TITLE
Fix queue_def reference to be get_qname.

### DIFF
--- a/src/rsmq/cmd/base_command.py
+++ b/src/rsmq/cmd/base_command.py
@@ -240,7 +240,7 @@ class BaseRSMQCommand:
         results = tx.execute()
 
         if not results or results[0][0] is None:
-            raise QueueDoesNotExist(self.get_queue)
+            raise QueueDoesNotExist(self.get_qname)
         stats = results[0]
         redis_time = results[1]
 


### PR DESCRIPTION
This change fixes a crash that occurred if you specify a non-existent queue. Previously, `BaseCommand#queue_def` would erroneously attempt to call `get_queue` instead of `get_qname` when throwing an exception.

Error message:
```
Traceback (most recent call last):
  File "/Users/rwl4/.local/lib/python3.12/site-packages/flask/app.py", line 1498, in __call__
    return self.wsgi_app(environ, start_response)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rwl4/.local/lib/python3.12/site-packages/flask/app.py", line 1476, in wsgi_app
    response = self.handle_exception(e)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rwl4/.local/lib/python3.12/site-packages/flask/app.py", line 1473, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rwl4/.local/lib/python3.12/site-packages/flask/app.py", line 882, in full_dispatch_request
    rv = self.handle_user_exception(e)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rwl4/.local/lib/python3.12/site-packages/flask/app.py", line 880, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rwl4/.local/lib/python3.12/site-packages/flask/app.py", line 865, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rwl4/Projects/SQS/demo/rsmq_server.py", line 26, in sqs_handler
    return generate_response("ReceiveMessageResponse", receive_message_handler())
                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rwl4/Projects/SQS/demo/rsmq_server.py", line 75, in receive_message_handler
    message = queue.receiveMessage(qname="test").execute()
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rwl4/.local/lib/python3.12/site-packages/rsmq/cmd/base_command.py", line 210, in execute
    return self._exec()
           ^^^^^^^^^^^^
  File "/Users/rwl4/.local/lib/python3.12/site-packages/rsmq/cmd/base_command.py", line 226, in _exec
    return self.exec_command()
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/rwl4/.local/lib/python3.12/site-packages/rsmq/cmd/receive_message.py", line 25, in exec_command
    queue = self.queue_def()
            ^^^^^^^^^^^^^^^^
  File "/Users/rwl4/.local/lib/python3.12/site-packages/rsmq/cmd/base_command.py", line 243, in queue_def
    raise QueueDoesNotExist(self.get_queue)
                            ^^^^^^^^^^^^^^^
  File "/Users/rwl4/.local/lib/python3.12/site-packages/rsmq/cmd/base_command.py", line 138, in __getattr__
    raise AttributeError(
AttributeError: 'ReceiveMessageCommand' object has no attribute 'get_queue'
```