### PR TITLE
handle delete when message id bytes

### DIFF
--- a/src/rsmq/cmd/delete_message.py
+++ b/src/rsmq/cmd/delete_message.py
@@ -20,7 +20,9 @@ class DeleteMessageCommand(BaseRSMQCommand):
         """Exec Command"""
         result = self.get_transaction().execute()
 
-        if int(result[0]) == 1 and int(result[1]) > 0:
+        # 1 key deleted from zset
+        # 3 keys deleted from hash (message itself, receive count, first receive field)
+        if int(result[0]) == 1 and int(result[1]) == 3:
             return True
 
         return False
@@ -31,7 +33,9 @@ class DeleteMessageCommand(BaseRSMQCommand):
         queue_base = self.queue_base
         queue_key = self.queue_key
         message_id = self.get_id
-
+        # decode to string when provided as bytes
+        if isinstance(message_id, bytes):
+            message_id = message_id.decode('utf-8')
         tx = client.pipeline(transaction=True)
         tx.zrem(queue_base, message_id)
         tx.hdel(queue_key, message_id, "%s:rc" % message_id, "%s:fr" % message_id)


### PR DESCRIPTION
Decode message_id to `str` when it is provided as `bytes`.

Closes https://github.com/mlasevich/PyRSMQ/issues/17